### PR TITLE
Add google/go-querystring to glide.yaml.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,9 +4,7 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 default: build
 
 build: vendor fmtcheck
-	@rm -rf build/
-	@mkdir -p build/
-	CGO_ENABLED=0 go build -ldflags '-w -extldflags "-static"' -o build/terraform-provider-apigee
+	CGO_ENABLED=0 go install -ldflags '-w -extldflags "-static"'
 
 GLIDE := $(shell command -v glide 2> /dev/null)
 ifndef GLIDE

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,3 +8,4 @@ import:
 - package: github.com/satori/go.uuid
 - package: github.com/zambien/go-apigee-edge
 - package: github.com/bgentry/go-netrc/netrc
+- package: github.com/google/go-querystring/query


### PR DESCRIPTION
Due to the need to do a non-recursive dependency fetch, go-querystring is not automatically found and pulled by glide. The addition of this line allows for a successful build in a clean build environment.

Also, updated the makefile so output conforms with other plugins.