### PR TITLE
Access Token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,12 @@ EOF
 ```
 APIGEE_BASE_URI="https://someinternalapigee.yourdomain.suffix" # optional... defaults to Apigee's SaaS
 APIGEE_ORG="my-really-cool-apigee-org-name"
+
+# To authenticate with Apigee you can use user and password
 APIGEE_USER="some_dude@domain.suffix"
 APIGEE_PASSWORD="for_the_love_of_pete_please_use_a_strong_password"
+
+# Or you can use an Access Token from Apigee OAuth
 APIGEE_ACCESS_TOKEN="my-access-token"
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ APIGEE_BASE_URI="https://someinternalapigee.yourdomain.suffix" # optional... def
 APIGEE_ORG="my-really-cool-apigee-org-name"
 APIGEE_USER="some_dude@domain.suffix"
 APIGEE_PASSWORD="for_the_love_of_pete_please_use_a_strong_password"
+APIGEE_ACCESS_TOKEN="my-access-token"
 ```
 
 ## Simple Example

--- a/README.md
+++ b/README.md
@@ -191,13 +191,19 @@ Linux:
 `GOOS=linux GOARCH=amd64 go build -o terraform-provider-apigee-v0.0.X-linux64`
 
 ## Testing
-To run tests, use the following commands.  Note that you will need your credentials setup for the tests to run.
+To run tests, use the following commands.  Note that you will need your credentials setup for the tests to run. You can authenticate with your username/password OR an access token from Apigee OAuth.
 
-Set env vars for test:
+#### Set env vars for test using username/password:
 ```
 APIGEE_ORG="my-really-cool-apigee-org-name"
 APIGEE_USER="some_dude@domain.suffix"
 APIGEE_PASSWORD="for_the_love_of_pete_please_use_a_strong_password"
+```
+
+#### Set env vars for test using access token:
+```
+APIGEE_ORG="my-really-cool-apigee-org-name"
+APIGEE_ACCESS_TOKEN="my-access-token"
 ```
 
 From the project root:

--- a/apigee/provider.go
+++ b/apigee/provider.go
@@ -16,15 +16,21 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("APIGEE_BASE_URI", nil),
 				Description: "Apigee Edge Base URI",
 			},
+			"access_token": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("APIGEE_ACCESS_TOKEN", nil),
+				Description: "Apigee Access Token",
+			},
 			"user": &schema.Schema{
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("APIGEE_USER", nil),
 				Description: "Apigee User",
 			},
 			"password": &schema.Schema{
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("APIGEE_PASSWORD", nil),
 				Description: "Apigee User Password",
 			},
@@ -52,12 +58,11 @@ func Provider() terraform.ResourceProvider {
 }
 
 func configureProvider(d *schema.ResourceData) (interface{}, error) {
-
 	auth := apigee.EdgeAuth{
-		Username: d.Get("user").(string),
-		Password: d.Get("password").(string),
+		Username:    d.Get("user").(string),
+		Password:    d.Get("password").(string),
+		AccessToken: d.Get("access_token").(string),
 	}
-
 	opts := &apigee.EdgeClientOptions{
 		MgmtUrl: d.Get("base_uri").(string),
 		Org:     d.Get("org").(string),
@@ -68,6 +73,5 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	if err != nil {
 		return client, err
 	}
-
 	return client, nil
 }


### PR DESCRIPTION
Got this working and tested pushing a new product using apigee's access tokens. I changed the username/pw to be optional as now you can either have authentication via access token OR username/pw. 

Lemme know whatcha think. Thanks!