### PR TITLE
Added ability to create target server without ssl_info configuration

### DIFF
--- a/apigee/resource_target_server.go
+++ b/apigee/resource_target_server.go
@@ -144,17 +144,19 @@ func resourceTargetServerImport(d *schema.ResourceData, meta interface{}) ([]*sc
 	d.Set("port", targetServerData.Port)
 	d.Set("env", IDEnv)
 
-	protocols := flattenStringList(targetServerData.SSLInfo.Protocols)
-	ciphers := flattenStringList(targetServerData.SSLInfo.Ciphers)
+	if targetServerData.SSLInfo != nil {
+		protocols := flattenStringList(targetServerData.SSLInfo.Protocols)
+		ciphers := flattenStringList(targetServerData.SSLInfo.Ciphers)
 
-	d.Set("ssl_info.0.ssl_enabled", targetServerData.SSLInfo.SSLEnabled)
-	d.Set("ssl_info.0.client_auth_enabled", targetServerData.SSLInfo.ClientAuthEnabled)
-	d.Set("ssl_info.0.key_store", targetServerData.SSLInfo.KeyStore)
-	d.Set("ssl_info.0.trust_store", targetServerData.SSLInfo.TrustStore)
-	d.Set("ssl_info.0.key_alias", targetServerData.SSLInfo.KeyAlias)
-	d.Set("ssl_info.0.ciphers", ciphers)
-	d.Set("ssl_info.0.ignore_validation_errors", targetServerData.SSLInfo.IgnoreValidationErrors)
-	d.Set("ssl_info.0.protocols", protocols)
+		d.Set("ssl_info.0.ssl_enabled", targetServerData.SSLInfo.SSLEnabled)
+		d.Set("ssl_info.0.client_auth_enabled", targetServerData.SSLInfo.ClientAuthEnabled)
+		d.Set("ssl_info.0.key_store", targetServerData.SSLInfo.KeyStore)
+		d.Set("ssl_info.0.trust_store", targetServerData.SSLInfo.TrustStore)
+		d.Set("ssl_info.0.key_alias", targetServerData.SSLInfo.KeyAlias)
+		d.Set("ssl_info.0.ciphers", ciphers)
+		d.Set("ssl_info.0.ignore_validation_errors", targetServerData.SSLInfo.IgnoreValidationErrors)
+		d.Set("ssl_info.0.protocols", protocols)
+	}
 
 	return []*schema.ResourceData{d}, nil
 }
@@ -181,17 +183,19 @@ func resourceTargetServerRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("enabled", targetServerData.Enabled)
 	d.Set("port", targetServerData.Port)
 
-	protocols := flattenStringList(targetServerData.SSLInfo.Protocols)
-	ciphers := flattenStringList(targetServerData.SSLInfo.Ciphers)
+	if targetServerData.SSLInfo != nil {
+		protocols := flattenStringList(targetServerData.SSLInfo.Protocols)
+		ciphers := flattenStringList(targetServerData.SSLInfo.Ciphers)
 
-	d.Set("ssl_info.0.ssl_enabled", targetServerData.SSLInfo.SSLEnabled)
-	d.Set("ssl_info.0.client_auth_enabled", targetServerData.SSLInfo.ClientAuthEnabled)
-	d.Set("ssl_info.0.key_store", targetServerData.SSLInfo.KeyStore)
-	d.Set("ssl_info.0.trust_store", targetServerData.SSLInfo.TrustStore)
-	d.Set("ssl_info.0.key_alias", targetServerData.SSLInfo.KeyAlias)
-	d.Set("ssl_info.0.ciphers", ciphers)
-	d.Set("ssl_info.0.ignore_validation_errors", targetServerData.SSLInfo.IgnoreValidationErrors)
-	d.Set("ssl_info.0.protocols", protocols)
+		d.Set("ssl_info.0.ssl_enabled", targetServerData.SSLInfo.SSLEnabled)
+		d.Set("ssl_info.0.client_auth_enabled", targetServerData.SSLInfo.ClientAuthEnabled)
+		d.Set("ssl_info.0.key_store", targetServerData.SSLInfo.KeyStore)
+		d.Set("ssl_info.0.trust_store", targetServerData.SSLInfo.TrustStore)
+		d.Set("ssl_info.0.key_alias", targetServerData.SSLInfo.KeyAlias)
+		d.Set("ssl_info.0.ciphers", ciphers)
+		d.Set("ssl_info.0.ignore_validation_errors", targetServerData.SSLInfo.IgnoreValidationErrors)
+		d.Set("ssl_info.0.protocols", protocols)
+	}
 
 	return nil
 }
@@ -237,22 +241,19 @@ func setTargetServerData(d *schema.ResourceData) (apigee.TargetServer, error) {
 
 	port_int, _ := strconv.Atoi(d.Get("port").(string))
 
-	ciphers := []string{""}
-	if d.Get("ssl_info.0.ciphers") != nil {
-		ciphers = getStringList("ssl_info.0.ciphers", d)
-	}
+	var ssl_info *apigee.SSLInfo
+	if d.Get("ssl_info") != nil {
+		ciphers := []string{""}
+		if d.Get("ssl_info.0.ciphers") != nil {
+			ciphers = getStringList("ssl_info.0.ciphers", d)
+		}
 
-	protocols := []string{""}
-	if d.Get("ssl_info.0.protocols") != nil {
-		protocols = getStringList("ssl_info.0.protocols", d)
-	}
+		protocols := []string{""}
+		if d.Get("ssl_info.0.protocols") != nil {
+			protocols = getStringList("ssl_info.0.protocols", d)
+		}
 
-	targetServer := apigee.TargetServer{
-		Name:    d.Get("name").(string),
-		Host:    d.Get("host").(string),
-		Enabled: d.Get("enabled").(bool),
-		Port:    port_int,
-		SSLInfo: apigee.SSLInfo{
+		ssl_info = &apigee.SSLInfo{
 			SSLEnabled:        d.Get("ssl_info.0.ssl_enabled").(string),
 			ClientAuthEnabled: d.Get("ssl_info.0.client_auth_enabled").(string),
 			KeyStore:          d.Get("ssl_info.0.key_store").(string),
@@ -262,7 +263,15 @@ func setTargetServerData(d *schema.ResourceData) (apigee.TargetServer, error) {
 			//Ciphers: d.Get("ssl_info.0.ciphers").([]string),
 			IgnoreValidationErrors: d.Get("ssl_info.0.ignore_validation_errors").(bool),
 			Protocols:              protocols,
-		},
+		}
+	}
+
+	targetServer := apigee.TargetServer{
+		Name:    d.Get("name").(string),
+		Host:    d.Get("host").(string),
+		Enabled: d.Get("enabled").(bool),
+		Port:    port_int,
+		SSLInfo: ssl_info,
 	}
 
 	return targetServer, nil

--- a/apigee/resource_target_server_test.go
+++ b/apigee/resource_target_server_test.go
@@ -31,9 +31,9 @@ func TestAccTargetServer_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"apigee_target_server.foo", "port", "80"),
 					resource.TestCheckResourceAttr(
-						"apigee_target_server.foo", "ssl_info.0.ssl_enabled", "0"),
+						"apigee_target_server.foo", "ssl_info.0.ssl_enabled", "false"),
 					resource.TestCheckResourceAttr(
-						"apigee_target_server.foo", "ssl_info.0.client_auth_enabled", "0"),
+						"apigee_target_server.foo", "ssl_info.0.client_auth_enabled", "false"),
 					resource.TestCheckResourceAttr(
 						"apigee_target_server.foo", "ssl_info.0.ignore_validation_errors", "false"),
 				),
@@ -53,9 +53,9 @@ func TestAccTargetServer_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"apigee_target_server.foo", "port", "443"),
 					resource.TestCheckResourceAttr(
-						"apigee_target_server.foo", "ssl_info.0.ssl_enabled", "1"),
+						"apigee_target_server.foo", "ssl_info.0.ssl_enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"apigee_target_server.foo", "ssl_info.0.client_auth_enabled", "1"),
+						"apigee_target_server.foo", "ssl_info.0.client_auth_enabled", "true"),
 					resource.TestCheckResourceAttr(
 						"apigee_target_server.foo", "ssl_info.0.key_store", "freetrial"),
 					resource.TestCheckResourceAttr(
@@ -65,9 +65,37 @@ func TestAccTargetServer_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"apigee_target_server.foo", "ssl_info.0.ignore_validation_errors", "true"),
 					resource.TestCheckResourceAttr(
-						"apigee_target_server.foo", "ssl_info.0.ciphers.0", "AES256"),
+						"apigee_target_server.foo", "ssl_info.0.ciphers.0", "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384"),
 					resource.TestCheckResourceAttr(
-						"apigee_target_server.foo", "ssl_info.0.protocols.0", "https"),
+						"apigee_target_server.foo", "ssl_info.0.protocols.0", "TLSv1.2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTargetServer_CreateWithoutSSLInfo(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTargetServerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckTargetServerConfigWithoutSSLInfo,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTargetServerExists("apigee_target_server.foo", "foo_target_server"),
+					resource.TestCheckResourceAttr(
+						"apigee_target_server.foo", "name", "foo_target_server"),
+					resource.TestCheckResourceAttr(
+						"apigee_target_server.foo", "host", "https://some.api.com"),
+					resource.TestCheckResourceAttr(
+						"apigee_target_server.foo", "env", "test"),
+					resource.TestCheckResourceAttr(
+						"apigee_target_server.foo", "enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"apigee_target_server.foo", "port", "80"),
+					resource.TestCheckNoResourceAttr(
+						"apigee_target_server.foo", "ssl_info.#"),
 				),
 			},
 		},
@@ -126,9 +154,19 @@ resource "apigee_target_server" "foo" {
     trust_store = "freetrial"
     key_alias = "freetrial"
     ignore_validation_errors = true # don't really do this...
-    ciphers = ["AES256"]
-    protocols = ["https"]
+    ciphers = ["TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384"]
+    protocols = ["TLSv1.2"]
   }
+}
+`
+
+const testAccCheckTargetServerConfigWithoutSSLInfo = `
+resource "apigee_target_server" "foo" {
+  name = "foo_target_server"
+  host = "https://some.api.com"
+  env = "test"
+  enabled = true
+  port = 80
 }
 `
 


### PR DESCRIPTION
Hello,

ApiGee target server behaves differently when created like:
```json
{
  "name" : "asdf-target",
  "host" : "host.123",
  "isEnabled" : true,
  "port" : 80,
  "sSLInfo": {}
 }
```
and like:
```json
{
  "name" : "asdf-target",
  "host" : "host.123",
  "isEnabled" : true,
  "port" : 80
 }
```

So... there should be the ability to create such target server (without ssl_info object defined).

I have added that possibility, fixed acceptance tests for this resource and added new test checking new functionality. It would be great to have that merged :)

NOTE: small change in go-apigee-edge was needed to make it work (https://github.com/zambien/go-apigee-edge/pull/10).