### PR TITLE
Changes to target server port not detected - fix type error

### DIFF
--- a/apigee/resource_target_server.go
+++ b/apigee/resource_target_server.go
@@ -176,10 +176,12 @@ func resourceTargetServerRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	port_str := strconv.Itoa(targetServerData.Port)
+
 	d.Set("name", targetServerData.Name)
 	d.Set("host", targetServerData.Host)
 	d.Set("enabled", targetServerData.Enabled)
-	d.Set("port", targetServerData.Port)
+	d.Set("port", port_str)
 
 	protocols := flattenStringList(targetServerData.SSLInfo.Protocols)
 	ciphers := flattenStringList(targetServerData.SSLInfo.Ciphers)


### PR DESCRIPTION
Hello!

Thank you for creating this project - something like terraform is much needed for Apigee and I expect this will be very helpful.
I did some testing and noticed that changes made to the port number of a target server weren't being detected by terraform. I suspected that this was a type error, and as a test if I handle the error from `d.Set("port", targetServerData.Port)` I see `expected type 'string', got unconvertible type 'int'`. Proposed fix is to convert similar to when setting the data.