### PR TITLE
use computed for company and dev apps

### DIFF
--- a/apigee/resource_company.go
+++ b/apigee/resource_company.go
@@ -146,11 +146,6 @@ func setCompanyData(d *schema.ResourceData) (apigee.Company, error) {
 		d.Set("display_name", d.Get("name"))
 	}
 
-	apps := []string{""}
-	if d.Get("apps") != nil {
-		apps = getStringList("apps", d)
-	}
-
 	attributes := []apigee.Attribute{}
 	if d.Get("attributes") != nil {
 		attributes = attributesFromMap(d.Get("attributes").(map[string]interface{}))
@@ -161,7 +156,6 @@ func setCompanyData(d *schema.ResourceData) (apigee.Company, error) {
 		DisplayName: d.Get("display_name").(string),
 		Attributes:  attributes,
 
-		Apps:   apps,
 		Status: d.Get("status").(string),
 	}
 

--- a/apigee/resource_company.go
+++ b/apigee/resource_company.go
@@ -33,7 +33,7 @@ func resourceCompany() *schema.Resource {
 			},
 			"apps": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"status": {

--- a/apigee/resource_developer.go
+++ b/apigee/resource_developer.go
@@ -40,7 +40,7 @@ func resourceDeveloper() *schema.Resource {
 			},
 			"apps": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"developer_id": {

--- a/apigee/resource_developer.go
+++ b/apigee/resource_developer.go
@@ -151,11 +151,6 @@ func setDeveloperData(d *schema.ResourceData) (apigee.Developer, error) {
 
 	log.Print("[DEBUG] setDeveloperData START")
 
-	apps := []string{""}
-	if d.Get("apps") != nil {
-		apps = getStringList("apps", d)
-	}
-
 	attributes := []apigee.Attribute{}
 	if d.Get("attributes") != nil {
 		attributes = attributesFromMap(d.Get("attributes").(map[string]interface{}))
@@ -167,7 +162,6 @@ func setDeveloperData(d *schema.ResourceData) (apigee.Developer, error) {
 		LastName:   d.Get("last_name").(string),
 		UserName:   d.Get("user_name").(string),
 		Attributes: attributes,
-		Apps:       apps,
 	}
 
 	return Developer, nil

--- a/apigee/resource_developer_app_test.go
+++ b/apigee/resource_developer_app_test.go
@@ -44,7 +44,7 @@ func TestAccDeveloperApp_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"apigee_developer_app.foo_developer_app", "scopes.0", "READ"),
 					resource.TestCheckResourceAttr(
-						"apigee_developer_app.foo_developer_app", "callback_url", "http://www.google.com"),
+						"apigee_developer_app.foo_developer_app", "callback_url", "https://www.google.com"),
 					//match integer
 					resource.TestMatchResourceAttr(
 						"apigee_developer_app.foo_developer_app", "key_expires_in", regexp.MustCompile("^[-+]?\\d+$")),

--- a/apigee/resource_product_test.go
+++ b/apigee/resource_product_test.go
@@ -44,7 +44,7 @@ func TestAccProduct_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"apigee_product.foo_product", "api_resources.0", "/**"),
 					resource.TestCheckResourceAttr(
-						"apigee_product.foo_product", "proxies.0", "helloworld"),
+						"apigee_product.foo_product", "proxies.0", "tf_helloworld"),
 					resource.TestCheckResourceAttr(
 						"apigee_product.foo_product", "quota", "1000"),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
Since some recent changes Apigee is now returning apps back from the company and dev APIs even when none are passed in.  This causes issues when we use company_apps or developer_apps as the plan will come back expecting  to make more changes.  For example:

```hcl
resource "apigee_company" "foo_company" {
   name = "foo_company"
}

resource "apigee_company_app" "foo_company_app" {
   name = "foo_company_app_name"
   company_name = "${apigee_company.foo_company.name}"
}
```

Would result in the following plan afterwards:

```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # apigee_company.foo_company will be updated in-place
  ~ resource "apigee_company" "foo_company" {
      ~ apps         = [
          - "foo_company_app_name",
        ]
        display_name = "foo_company"
        id           = "04f5741b-50d4-47db-b02d-6daa459b7863"
        name         = "foo_company"
        status       = "active"
    }

Plan: 0 to add, 1 to change, 0 to destroy.

------------------------------------------------------------------------
```

Setting the type to computed solves the problem but assumes that you are doing all of your management of the company or developer in question in terraform.

Prior to merging this I wanted to get some feedback. 