### PR TITLE
Allow multiple deployments

### DIFF
--- a/apigee/resource_company.go
+++ b/apigee/resource_company.go
@@ -146,11 +146,6 @@ func setCompanyData(d *schema.ResourceData) (apigee.Company, error) {
 		d.Set("display_name", d.Get("name"))
 	}
 
-	apps := []string{""}
-	if d.Get("apps") != nil {
-		apps = getStringList("apps", d)
-	}
-
 	attributes := []apigee.Attribute{}
 	if d.Get("attributes") != nil {
 		attributes = attributesFromMap(d.Get("attributes").(map[string]interface{}))
@@ -161,7 +156,6 @@ func setCompanyData(d *schema.ResourceData) (apigee.Company, error) {
 		DisplayName: d.Get("display_name").(string),
 		Attributes:  attributes,
 
-		Apps:   apps,
 		Status: d.Get("status").(string),
 	}
 

--- a/apigee/resource_company.go
+++ b/apigee/resource_company.go
@@ -33,7 +33,7 @@ func resourceCompany() *schema.Resource {
 			},
 			"apps": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"status": {

--- a/apigee/resource_developer.go
+++ b/apigee/resource_developer.go
@@ -40,7 +40,7 @@ func resourceDeveloper() *schema.Resource {
 			},
 			"apps": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"developer_id": {

--- a/apigee/resource_developer.go
+++ b/apigee/resource_developer.go
@@ -151,11 +151,6 @@ func setDeveloperData(d *schema.ResourceData) (apigee.Developer, error) {
 
 	log.Print("[DEBUG] setDeveloperData START")
 
-	apps := []string{""}
-	if d.Get("apps") != nil {
-		apps = getStringList("apps", d)
-	}
-
 	attributes := []apigee.Attribute{}
 	if d.Get("attributes") != nil {
 		attributes = attributesFromMap(d.Get("attributes").(map[string]interface{}))
@@ -167,7 +162,6 @@ func setDeveloperData(d *schema.ResourceData) (apigee.Developer, error) {
 		LastName:   d.Get("last_name").(string),
 		UserName:   d.Get("user_name").(string),
 		Attributes: attributes,
-		Apps:       apps,
 	}
 
 	return Developer, nil

--- a/apigee/resource_developer_app_test.go
+++ b/apigee/resource_developer_app_test.go
@@ -44,7 +44,7 @@ func TestAccDeveloperApp_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"apigee_developer_app.foo_developer_app", "scopes.0", "READ"),
 					resource.TestCheckResourceAttr(
-						"apigee_developer_app.foo_developer_app", "callback_url", "http://www.google.com"),
+						"apigee_developer_app.foo_developer_app", "callback_url", "https://www.google.com"),
 					//match integer
 					resource.TestMatchResourceAttr(
 						"apigee_developer_app.foo_developer_app", "key_expires_in", regexp.MustCompile("^[-+]?\\d+$")),

--- a/apigee/resource_product_test.go
+++ b/apigee/resource_product_test.go
@@ -44,7 +44,7 @@ func TestAccProduct_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"apigee_product.foo_product", "api_resources.0", "/**"),
 					resource.TestCheckResourceAttr(
-						"apigee_product.foo_product", "proxies.0", "helloworld"),
+						"apigee_product.foo_product", "proxies.0", "tf_helloworld"),
 					resource.TestCheckResourceAttr(
 						"apigee_product.foo_product", "quota", "1000"),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
fixes #28 

The issue here occurred because we always took the latest deployment and returned it.  Now we will select the actual deployment that is active.  Note that this requires users to manage multiple proxy deployments if they want to do this.  An example of this is:

apply 1:
```hcl
resource "apigee_api_proxy" "tf1_helloworld" {
   name         = "tf1_helloworld"
   bundle       = "${path.module}/helloworld_proxy.zip"
   bundle_sha   = "${filebase64sha256("helloworld_proxy.zip")}"
}

resource "apigee_api_proxy_deployment" "foo_api_proxy_deployment" {
   proxy_name   = "${apigee_api_proxy.tf1_helloworld.name}"
   org          = "zambien-trial"
   env          = "test"
   revision     = "1"
}
```

apply 2:
```hcl
resource "apigee_api_proxy" "tf1_helloworld" {
   name         = "tf1_helloworld"
   bundle       = "${path.module}/helloworld_proxy2.zip"
   bundle_sha   = "${filebase64sha256("helloworld_proxy2.zip")}"
}

resource "apigee_api_proxy_deployment" "foo_api_proxy_deployment" {
   proxy_name   = "${apigee_api_proxy.tf1_helloworld.name}"
   org          = "zambien-trial"
   env          = "test"
   revision     = "1"
}


resource "apigee_api_proxy_deployment" "foo_api_proxy_deployment2" {
   proxy_name   = "${apigee_api_proxy.tf1_helloworld.name}"
   org          = "zambien-trial"
   env          = "test"
   revision     = "latest" #or 2
   override     = true
}
```

I also made a fix for errors which would occur if using `latest` on a proxy deployment when the proxy was already deployed.

The output of `terraform show` after running both applies is:

```
# apigee_api_proxy.tf1_helloworld:
resource "apigee_api_proxy" "tf1_helloworld" {
    bundle       = "./helloworld_proxy2.zip"
    bundle_sha   = "bcRaaj0Vcp2biHPvQBiElVhopfY+h4ngZTQrhljIezE="
    id           = "adbc4519-f457-4601-9d95-697829cd60bb"
    name         = "tf1_helloworld"
    revision     = "2"
    revision_sha = "bcRaaj0Vcp2biHPvQBiElVhopfY+h4ngZTQrhljIezE="
}

# apigee_api_proxy_deployment.foo_api_proxy_deployment:
resource "apigee_api_proxy_deployment" "foo_api_proxy_deployment" {
    delay      = 0
    env        = "test"
    id         = "e721e174-843a-4f72-9c6c-3fea8918d574"
    org        = "zambien-trial"
    override   = false
    proxy_name = "tf1_helloworld"
    revision   = "1"
}

# apigee_api_proxy_deployment.foo_api_proxy_deployment2:
resource "apigee_api_proxy_deployment" "foo_api_proxy_deployment2" {
    delay      = 0
    env        = "test"
    id         = "2b01cba5-4366-4c3c-988c-e11d27edb85d"
    org        = "zambien-trial"
    override   = true
    proxy_name = "tf1_helloworld"
    revision   = "2"
}
```