### PR TITLE
docs: update target server docs to use string data type for SSL boolean properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ resource "apigee_target_server" "helloworld_target_server_testing" {
    port = 8080
 
    ssl_info {
-      ssl_enabled = false
-      client_auth_enabled = false
+      ssl_enabled = "false"
+      client_auth_enabled = "false"
       key_store = ""
       trust_store = ""
       key_alias = ""


### PR DESCRIPTION
See [source resource documentation](https://github.com/ericksoen/terraform-provider-apigee/blob/update-target-server-docs/apigee/resource_target_server.go#L53-#L61) 

See also [Terraform booleans](https://www.terraform.io/docs/configuration-0-11/variables.html#booleans)