### PR TITLE
Fix api_proxy delete method to only succeed when proxy is deleted

### DIFF
--- a/apigee/resource_api_proxy.go
+++ b/apigee/resource_api_proxy.go
@@ -160,9 +160,13 @@ func resourceApiProxyDelete(d *schema.ResourceData, meta interface{}) error {
 				log.Printf("[ERROR] resourceApiProxyDelete error deleting api_proxy: %s", err.Error())
 				return fmt.Errorf("[ERROR] resourceApiProxyDelete error deleting api_proxy: %s", err.Error())
 			}
+		} else {
+			deleted = true
 		}
-		deleted = true
-		tries += tries
+		tries += 1
+	}
+	if !deleted {
+		return fmt.Errorf("[ERROR] unable to delete ApiProxy")
 	}
 
 	return nil


### PR DESCRIPTION
Previously, when the delete method fails to delete the proxy it still claims to have succeeded and removes the proxy from state.
For example, when a proxy has a deployment associated with it it cannot be deleted.
This was due to a small bug in the delete method.


Added a test to check this behaviour.