### PR TITLE
Fix get latest revision bug

### DIFF
--- a/apigee/resource_api_proxy.go
+++ b/apigee/resource_api_proxy.go
@@ -5,7 +5,6 @@ import (
 
 	"fmt"
 	"log"
-	"strconv"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -80,7 +79,7 @@ func resourceApiProxyImport(d *schema.ResourceData, meta interface{}) ([]*schema
 	if err != nil {
 		return []*schema.ResourceData{}, fmt.Errorf("[DEBUG] resourceApiProxyImport. Error getting deployment api: %v", err)
 	}
-	latestRev := strconv.Itoa(proxy.Revisions[len(proxy.Revisions)-1])
+	latestRev := int(proxy.Revisions[len(proxy.Revisions)-1])
 	d.Set("revision", latestRev)
 	d.Set("name", d.Id())
 	return []*schema.ResourceData{d}, nil
@@ -103,7 +102,7 @@ func resourceApiProxyRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	latest_rev := strconv.Itoa(u.Revisions[len(u.Revisions)-1])
+	latest_rev := int(u.Revisions[len(u.Revisions)-1])
 
 	log.Printf("[DEBUG] resourceApiProxyRead.  revision_sha before: %#v", d.Get("revision_sha").(string))
 	d.Set("revision_sha", d.Get("bundle_sha").(string))

--- a/apigee/resource_api_proxy.go
+++ b/apigee/resource_api_proxy.go
@@ -80,7 +80,7 @@ func resourceApiProxyImport(d *schema.ResourceData, meta interface{}) ([]*schema
 	if err != nil {
 		return []*schema.ResourceData{}, fmt.Errorf("[DEBUG] resourceApiProxyImport. Error getting deployment api: %v", err)
 	}
-	latestRev := strconv.Itoa(len(proxy.Revisions))
+	latestRev := strconv.Itoa(proxy.Revisions[len(proxy.Revisions)-1])
 	d.Set("revision", latestRev)
 	d.Set("name", d.Id())
 	return []*schema.ResourceData{d}, nil
@@ -103,7 +103,7 @@ func resourceApiProxyRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	latest_rev := strconv.Itoa(len(u.Revisions))
+	latest_rev := strconv.Itoa(u.Revisions[len(u.Revisions)-1])
 
 	log.Printf("[DEBUG] resourceApiProxyRead.  revision_sha before: %#v", d.Get("revision_sha").(string))
 	d.Set("revision_sha", d.Get("bundle_sha").(string))

--- a/apigee/resource_api_proxy.go
+++ b/apigee/resource_api_proxy.go
@@ -79,7 +79,7 @@ func resourceApiProxyImport(d *schema.ResourceData, meta interface{}) ([]*schema
 	if err != nil {
 		return []*schema.ResourceData{}, fmt.Errorf("[DEBUG] resourceApiProxyImport. Error getting deployment api: %v", err)
 	}
-	latestRev := int(proxy.Revisions[len(proxy.Revisions)-1])
+	latestRev := proxy.Revisions[len(proxy.Revisions)-1]
 	d.Set("revision", latestRev)
 	d.Set("name", d.Id())
 	return []*schema.ResourceData{d}, nil
@@ -102,7 +102,7 @@ func resourceApiProxyRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	latest_rev := int(u.Revisions[len(u.Revisions)-1])
+	latest_rev := u.Revisions[len(u.Revisions)-1]
 
 	log.Printf("[DEBUG] resourceApiProxyRead.  revision_sha before: %#v", d.Get("revision_sha").(string))
 	d.Set("revision_sha", d.Get("bundle_sha").(string))

--- a/apigee/resource_api_proxy_deployment.go
+++ b/apigee/resource_api_proxy_deployment.go
@@ -255,6 +255,11 @@ func getLatestRevision(client *apigee.EdgeClient, proxyName string) (int, error)
 	if err != nil {
 		return -1, fmt.Errorf("[ERROR] resourceApiProxyRead error reading proxies: %s", err.Error())
 	}
-	latestRev := proxy.Revisions[len(proxy.Revisions)-1]
-	return int(latestRev), nil
+
+	latestRev, err := strconv.Atoi(proxy.Revisions[len(proxy.Revisions)-1].String())
+	if err != nil {
+		return -1, fmt.Errorf("[ERROR] resourceApiProxyRead error reading proxies: %s", err.Error())
+	}
+
+	return latestRev, nil
 }

--- a/apigee/resource_api_proxy_deployment.go
+++ b/apigee/resource_api_proxy_deployment.go
@@ -255,5 +255,6 @@ func getLatestRevision(client *apigee.EdgeClient, proxyName string) (int, error)
 	if err != nil {
 		return -1, fmt.Errorf("[ERROR] resourceApiProxyRead error reading proxies: %s", err.Error())
 	}
-	return len(proxy.Revisions), nil
+	latestRev := proxy.Revisions[len(proxy.Revisions)-1]
+	return int(latestRev), nil
 }

--- a/apigee/resource_api_proxy_deployment_test.go
+++ b/apigee/resource_api_proxy_deployment_test.go
@@ -2,12 +2,13 @@ package apigee
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
-	"github.com/zambien/go-apigee-edge"
 	"log"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/zambien/go-apigee-edge"
 )
 
 func TestAccProxyDeployment_Updated(t *testing.T) {

--- a/apigee/resource_developer.go
+++ b/apigee/resource_developer.go
@@ -2,11 +2,12 @@ package apigee
 
 import (
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/zambien/go-apigee-edge"
-	"log"
-	"strings"
 )
 
 func resourceDeveloper() *schema.Resource {

--- a/apigee/resource_shared_flow.go
+++ b/apigee/resource_shared_flow.go
@@ -80,7 +80,8 @@ func resourceSharedFlowImport(d *schema.ResourceData, meta interface{}) ([]*sche
 	if err != nil {
 		return []*schema.ResourceData{}, fmt.Errorf("[DEBUG] resourceSharedFlowImport. Error getting deployment shared flow: %v", err)
 	}
-	latestRev := strconv.Itoa(len(sharedFlow.Revisions))
+	latestRev := strconv.Itoa(sharedFlow.Revisions[len(sharedFlow.Revisions)-1])
+
 	d.Set("revision", latestRev)
 	d.Set("name", d.Id())
 	return []*schema.ResourceData{d}, nil
@@ -103,7 +104,7 @@ func resourceSharedFlowRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	latestRev := strconv.Itoa(len(u.Revisions))
+	latestRev := strconv.Itoa(u.Revisions[len(u.Revisions)-1])
 
 	log.Printf("[DEBUG] resourceSharedFlowRead.  revision_sha before: %#v", d.Get("revision_sha").(string))
 	d.Set("revision_sha", d.Get("bundle_sha").(string))

--- a/apigee/resource_shared_flow.go
+++ b/apigee/resource_shared_flow.go
@@ -5,7 +5,6 @@ import (
 
 	"fmt"
 	"log"
-	"strconv"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -80,7 +79,7 @@ func resourceSharedFlowImport(d *schema.ResourceData, meta interface{}) ([]*sche
 	if err != nil {
 		return []*schema.ResourceData{}, fmt.Errorf("[DEBUG] resourceSharedFlowImport. Error getting deployment shared flow: %v", err)
 	}
-	latestRev := strconv.Itoa(sharedFlow.Revisions[len(sharedFlow.Revisions)-1])
+	latestRev := int(sharedFlow.Revisions[len(sharedFlow.Revisions)-1])
 
 	d.Set("revision", latestRev)
 	d.Set("name", d.Id())
@@ -104,7 +103,7 @@ func resourceSharedFlowRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	latestRev := strconv.Itoa(u.Revisions[len(u.Revisions)-1])
+	latestRev := int(u.Revisions[len(u.Revisions)-1])
 
 	log.Printf("[DEBUG] resourceSharedFlowRead.  revision_sha before: %#v", d.Get("revision_sha").(string))
 	d.Set("revision_sha", d.Get("bundle_sha").(string))

--- a/apigee/resource_shared_flow.go
+++ b/apigee/resource_shared_flow.go
@@ -79,7 +79,7 @@ func resourceSharedFlowImport(d *schema.ResourceData, meta interface{}) ([]*sche
 	if err != nil {
 		return []*schema.ResourceData{}, fmt.Errorf("[DEBUG] resourceSharedFlowImport. Error getting deployment shared flow: %v", err)
 	}
-	latestRev := int(sharedFlow.Revisions[len(sharedFlow.Revisions)-1])
+	latestRev := sharedFlow.Revisions[len(sharedFlow.Revisions)-1]
 
 	d.Set("revision", latestRev)
 	d.Set("name", d.Id())
@@ -103,7 +103,7 @@ func resourceSharedFlowRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	latestRev := int(u.Revisions[len(u.Revisions)-1])
+	latestRev := u.Revisions[len(u.Revisions)-1]
 
 	log.Printf("[DEBUG] resourceSharedFlowRead.  revision_sha before: %#v", d.Get("revision_sha").(string))
 	d.Set("revision_sha", d.Get("bundle_sha").(string))

--- a/apigee/resource_shared_flow_deployment.go
+++ b/apigee/resource_shared_flow_deployment.go
@@ -253,5 +253,11 @@ func getLatestSharedFlowRevision(client *apigee.EdgeClient, sharedFlowName strin
 	if err != nil {
 		return -1, fmt.Errorf("[ERROR] getLatestSharedFlowRevision error reading shared flows: %s", err.Error())
 	}
-	return len(sharedFlow.Revisions), nil
+
+	latestRevision, err := strconv.Atoi(sharedFlow.Revisions[len(sharedFlow.Revisions)-1].String())
+	if err != nil {
+		return -1, fmt.Errorf("[ERROR] getLatestSharedFlowRevision error reading shared flows: %s", err.Error())
+	}
+
+	return latestRevision, nil
 }


### PR DESCRIPTION
Fix a critical bug where the latest revision is not actually getting the latest revision but getting the revision length. This caused our API proxy to unintentionally deploy an outdated broken revision.

### The problem and reproducing it
This bug can be reproduced by creating a proxy with multiple revisions and deleting an older revision. The apigee_api_proxy will grab "latest" by grabbing the length of the revision array but since it's missing 1 it will be short by 1. 
1. Create proxy with 3 revisions
2. Deploy to revision 3
3. Delete revision 1
4. Deployment to "latest" will deploy to revision 2 due to deleted revision

### Fix
- The fix consists of grabbing the last element in the Revisions array instead of assuming the length as the latest revision (normally works if deleting revisions wasn't an option). This fix works because the revisions array stores the actual revision numbers in a sorted array.
- It's assumed to be a sorted array of revisions (which appears to be true from testing)

--------

Please let me know if I need to make any updates (first time using Go)