### PR TITLE
V0.0.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ An example of how to do this would be:
 `mkdir -p ~/terraform-providers`
 
 2. Download plugin for linux into your home directory
-`curl -L https://github.com/zambien/terraform-provider-apigee/releases/download/v0.0.7/terraform-provider-apigee-v0.0.7-linux64 -o ~/terraform-providers/terraform-provider-apigee-v0.0.7-linux64`
+`curl -L https://github.com/zambien/terraform-provider-apigee/releases/download/v0.0.23/terraform-provider-apigee-v0.0.23-linux64 -o ~/terraform-providers/terraform-provider-apigee-v0.0.23-linux64`
 
 3. Add the providers clause if you don't already have one.  Warning, this command will overwrite your .terraformrc!
 ```
 cat << EOF > ~/.terraformrc
 providers {
-    apigee = "$HOME/terraform-providers/terraform-provider-apigee-v0.0.7-linux64"
+    apigee = "$HOME/terraform-providers/terraform-provider-apigee-v0.0.23-linux64"
 }
 EOF
 ```

--- a/README.md
+++ b/README.md
@@ -6,31 +6,17 @@ Allows Terraform deployments and management of Apigee API proxies, deployments, 
 
 https://registry.terraform.io/providers/zambien/apigee/
 
-## Installation
-
-Download the appropriate release for your system: https://github.com/zambien/terraform-provider-apigee/releases
-
-See here for info on how to install the plugin:
-
-https://www.terraform.io/docs/plugins/basics.html
-
-An example of how to do this would be:
-
-1. Make a terraform providers folder in home
-`mkdir -p ~/terraform-providers`
-
-2. Download plugin for linux into your home directory
-`curl -L https://github.com/zambien/terraform-provider-apigee/releases/download/v0.0.23/terraform-provider-apigee-v0.0.23-linux64 -o ~/terraform-providers/terraform-provider-apigee-v0.0.23-linux64`
-
-3. Add the providers clause if you don't already have one.  Warning, this command will overwrite your .terraformrc!
-```
-cat << EOF > ~/.terraformrc
-providers {
-    apigee = "$HOME/terraform-providers/terraform-provider-apigee-v0.0.23-linux64"
-}
-EOF
-```
-
+- [terraform-provider-apigee](#terraform-provider-apigee)
+  * [TFVARS for provider](#tfvars-for-provider)
+  * [Simple Example](#simple-example)
+  * [Contributions](#contributions)
+  * [Building](#building)
+  * [Testing](#testing)
+      - [Set env vars for test using username/password:](#set-env-vars-for-test-using-username-password-)
+      - [Set env vars for test using access token:](#set-env-vars-for-test-using-access-token-)
+  * [Releasing](#releasing)
+  * [Known issues](#known-issues)
+  
 ## TFVARS for provider
 
 ```
@@ -48,6 +34,25 @@ APIGEE_ACCESS_TOKEN="my-access-token"
 ## Simple Example
 
 ```
+
+# note, to test and build the plugin locally uncomment the lines below or do something like it
+# provider_version=0.0.x
+# mkdir -p ~/.terraform.d/plugins/local/zambien/apigee/${provider_version}/linux_amd64/
+# mv terraform-provider-apigee-v${provider_version}-linux64 ~/.terraform.d/plugins/local/zambien/apigee/${provider_version}/linux_amd64/terraform-provider-apigee_v${provider_version}
+
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    apigee = {
+      # pull from registry
+      source = "zambien/apigee"
+      # test locally built plugin
+      # source = "local/zambien/apigee"
+      version = "~> 0.0.23"
+    }
+  }
+}
 
 variable "org" { default = "my-really-cool-apigee-org-name" }
 variable "env" { default = "test" }
@@ -109,7 +114,8 @@ resource "apigee_api_proxy_deployment" "helloworld_proxy_deployment" {
 
    # NOTE: revision = "latest" 
    # will deploy the latest revision of the api proxy 
-   revision     = "${apigee_api_proxy.helloworld_proxy.revision}"
+   revision     = "latest"
+   # OR revision = "1" # for specific revision
 }
 
 # A target server
@@ -206,7 +212,8 @@ resource "apigee_shared_flow_deployment" "helloworld_shared_flow_deployment" {
 
    # NOTE: revision = "latest" 
    # will deploy the latest revision of the shared flow 
-   revision     = "${apigee_shared_flow.helloworld_shared_flow.revision}"
+   revision     = "latest"
+   # OR revision = "1" # for specific revision
 }
 ```
 
@@ -264,3 +271,7 @@ goreleaser # actually create the release
 You can read more about goreleaser here:
 
 https://goreleaser.com/
+
+## Known issues
+
+* You will often find the need to run apply twice when updating a proxy.  This has to do with how terraform handles state.  This plugin will be rewritten to combine proxies and proxy deployments to resolve this issue in the future.

--- a/apigee/helpers.go
+++ b/apigee/helpers.go
@@ -1,7 +1,6 @@
 package apigee
 
 import (
-	"github.com/17media/structs"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/zambien/go-apigee-edge"
 	"reflect"
@@ -60,16 +59,34 @@ func attributesFromMap(attributes map[string]interface{}) []apigee.Attribute {
 	return result
 }
 
-func mapFromCredentials(credentials []apigee.Credential) []interface{} {
+func flattenCredentials(in []apigee.Credential) []interface{} {
 
-	result := make([]interface{}, 0, len(credentials))
+	if in != nil {
 
-	for _, elem := range credentials {
-		credentialMap := structs.Map(elem)
-		result = append(result, credentialMap)
+		out := make([]interface{}, len(in), len(in))
+
+		for i, elem := range in {
+
+			m := make(map[string]interface{})
+
+			m["consumer_key"] = elem.ConsumerKey
+			m["consumer_secret"] = elem.ConsumerSecret
+			m["issued_at"] = elem.IssuedAt
+			m["expired_at"] = elem.ExpiresAt
+
+
+			/*
+			if len(elem.ApiProducts) > 0 {
+				m["port_mapping"] = flattenDockerPortMappings(elem.PortMappings)
+			}*/
+
+			out[i] = m
+		}
+
+		return out
 	}
 
-	return result
+	return make([]interface{}, 0)
 }
 
 func arraySortedEqual(a, b []string) bool {

--- a/apigee/resource_api_proxy_deployment.go
+++ b/apigee/resource_api_proxy_deployment.go
@@ -149,7 +149,7 @@ func resourceApiProxyDeploymentCreate(d *schema.ResourceData, meta interface{}) 
 		rev_int, err := getLatestRevision(client, proxy_name)
 		rev = apigee.Revision(rev_int)
 		if err != nil {
-			return fmt.Errorf("[ERROR] resourceApiProxyDeploymentUpdate error getting latest revision: %v", err)
+			return fmt.Errorf("[ERROR] resourceApiProxyDeploymentCreate error getting latest revision: %v", err)
 		}
 	}
 
@@ -210,7 +210,7 @@ func resourceApiProxyDeploymentUpdate(d *schema.ResourceData, meta interface{}) 
 
 	if err != nil {
 		log.Printf("[ERROR] resourceApiProxyDeploymentUpdate error redeploying: %s", err.Error())
-		if strings.Contains(err.Error(), " is already deployed into environment ") {
+		if strings.Contains(err.Error(), " is already deployed ") {
 			return resourceApiProxyDeploymentRead(d, meta)
 		}
 		return fmt.Errorf("[ERROR] resourceApiProxyDeploymentUpdate error redeploying: %s", err.Error())

--- a/apigee/resource_api_proxy_deployment.go
+++ b/apigee/resource_api_proxy_deployment.go
@@ -174,8 +174,10 @@ func resourceApiProxyDeploymentCreate(d *schema.ResourceData, meta interface{}) 
 	proxyDep, _, err := client.Proxies.Deploy(proxy_name, env, rev, delay, override)
 
 	if err != nil {
-
-		if strings.Contains(err.Error(), "conflicts with existing deployment path") {
+		if strings.Contains(err.Error(), " is already deployed ") {
+			log.Printf("[ERROR] resourceApiProxyDeploymentCreate error deploying.  We will read into state: %s", err.Error())
+			resourceApiProxyDeploymentUpdate(d, meta)
+		} else if strings.Contains(err.Error(), "conflicts with existing deployment path") {
 			//create, fail, update
 			log.Printf("[ERROR] resourceApiProxyDeploymentCreate error deploying: %s", err.Error())
 			log.Print("[DEBUG] resourceApiProxyDeploymentCreate something got out of sync... maybe someone messing around in apigee directly.  Terraform OVERRIDE!!!")

--- a/apigee/resource_api_proxy_deployment.go
+++ b/apigee/resource_api_proxy_deployment.go
@@ -138,11 +138,8 @@ func resourceApiProxyDeploymentRead(d *schema.ResourceData, meta interface{}) (e
 				log.Printf("[DEBUG] resourceApiProxyDeploymentRead latest deployed revision: %#v did not match actual latest revision: %#v. Updating revision to latest available. \n", matchedRevision, strconv.Itoa(rev_int))
 				d.Set("revision", strconv.Itoa(rev_int))
 			}
-
-			d.SetId(matchedRevision)
 		} else {
 			d.Set("revision", matchedRevision)
-			d.Set("deployed_revision", matchedRevision)
 		}
 		log.Printf("[DEBUG] resourceApiProxyDeploymentRead - deployment found. Revision is: %#v", d.Get("revision").(string))
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/17media/structs v0.0.0-20200317074636-7872972ebe57
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/hashicorp/terraform v0.12.13
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0 // indirect
 	github.com/zambien/go-apigee-edge v0.0.0-20191101145538-e45257f96262
 )


### PR DESCRIPTION
Resolves a few issues created by changes to plugin sdk changes and by some untested changes earlier for deprecating org in certain resources.  Note that in the future it will most likely make sense to combine the proxy and proxy deployment resources into one resource.  The same goes for shared flows. This will be the best way to remove the "latest" configuration and avoid double-applies.

resolves #67, #68, and #69

Note that you should use latest to get the inconsistent plan fix.  This will be resolved in a different way later on by combining proxy and proxy_deployment into one resource. 
